### PR TITLE
fix build issue with wrong names

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,7 +1,7 @@
 /* Basscss Utility White Space */
 
-@import "./lib/margins";
-@import "./lib/padding";
+@import "./lib/margins.css";
+@import "./lib/padding.css";
 
 :root {
   --space-1: .5rem;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basscss-utility-white-space",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "White space margin and padding utilities module for Basscss",
   "repository": {
     "type": "git",


### PR DESCRIPTION
There was variance in `./lib` file names and imports of `index.css` which leads to build errors. This update fixes it, could you please publish it to npm ASAP? Thanks!